### PR TITLE
daily and monthly filter works!

### DIFF
--- a/src/pages/DailyReport.js
+++ b/src/pages/DailyReport.js
@@ -30,19 +30,28 @@ const columns = [
 
 let dateobj = new Date()
 let month = (dateobj.getMonth()+1).toString()
-let curr = (dateobj.getDate()).toString()+"-"+month+"-"+(dateobj.getFullYear()).toString()
+let day = dateobj.getDate().toString()
+
+if (month.length == 1){
+  month = "0"+month
+}
+if (day.length == 1){
+  day = "0"+day
+}
+
+let curr = day+"-"+month+"-"+(dateobj.getFullYear()).toString()
 
 const DailyReport = (props) => {
   const classes = useStyles()
   const [customers, setCustomers] = useState([{ item: null }])
   const [deleted, setDeleted] = useState(false)
-  const [date, setDate] = useState("all")
+  const [date, setDate] = useState(curr)
   const [selection, setSelection] = useState([])
   const { currentUser } = useContext(AuthContext)
   const [dailyTot, setDailyTot] = useState([0])
 
   useEffect(() => {
-    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers`
+    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers/daily/`+curr
     fetch(apiUrl)
       .then((res) => res.json())
       .then((orders) => {
@@ -52,8 +61,10 @@ const DailyReport = (props) => {
           total += item.paid
         })
         setDailyTot(total)
+        console.log(curr)
+
       })
-  }, [deleted])
+  }, [deleted]||[date])
 
   const deleteEntries = (selected) => {
     var delIds = Array.from(selected)
@@ -71,14 +82,15 @@ const DailyReport = (props) => {
       })
     })
     setDeleted(!deleted)
-    setDate("all")
+    setDeleted(!deleted)
+    setDate(curr)
   }
 
   const handleChangeDate = e => {
     let newdate = moment((e.target.value)).format("DD-MM-YYYY")
     setDate(e.target.value);
     console.log(newdate)
-    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers/`+newdate
+    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers/daily/`+newdate
     fetch(apiUrl)
       .then((res) => res.json())
       .then((orders) => {

--- a/src/pages/MonthlyReport.js
+++ b/src/pages/MonthlyReport.js
@@ -34,10 +34,14 @@ const useStyles = makeStyles((theme) => ({
 // ];
 
 const columns = [
-  { field: 'date', headerName: 'Date', width: 150 },
-  { field: 'paid', headerName: 'Paid', width: 90 },
-  { field: 'services', headerName: 'Services', width: 400 },
+  { field: 'date', headerName: 'Date', width:200},
+  { field: 'paid', headerName: 'Paid'},
 ]
+
+var currmonth = (parseInt(new Date().getMonth())+1).toString()
+if (currmonth.length === 1){
+  currmonth = "0"+currmonth
+}
 
 const MonthlyReport = (props) => {
   // const [month, setMonth] = React.useState('');
@@ -45,11 +49,12 @@ const MonthlyReport = (props) => {
   const [customers, setCustomers] = useState([{ item: null }])
   const { currentUser } = useContext(AuthContext)
   const [monthlyTot, setMonthlyTot] = useState([0])
+  const [month, setMonth] = useState(currmonth)
   const classes = useStyles()
   const [value, setValue] = React.useState(new Date())
 
   useEffect(() => {
-    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers`
+    const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/Customers/monthly/`+month
     fetch(apiUrl)
       .then((res) => res.json())
       .then((orders) => {
@@ -62,7 +67,19 @@ const MonthlyReport = (props) => {
 
         setMonthlyTot(tot)
       })
-  }, [customers])
+  }, [month])
+
+  const changeMonth = (date) => {
+    date = new Date(date)
+    var selected = (parseInt(date.getMonth())+1).toString()
+    if (selected.length === 1){
+      selected = "0"+selected
+    }
+    setMonth(selected)
+    setMonth(selected)
+    console.log(selected+" "+currmonth)
+  }
+  
 
   //commented all these for faichan UwU - anonymous
   // useEffect(() => {
@@ -97,19 +114,20 @@ const MonthlyReport = (props) => {
             color='textPrimary'
             className={classes.title}
           >
-            Monthly Report
+            Monthly Report for {month}
           </Typography>
 
           <Grid className={classes.monthPicker}>
             <LocalizationProvider dateAdapter={AdapterDateFns}>
               <DatePicker
-                views={['year', 'month']}
+                views={['month']}
                 label='Pick a Month'
                 minDate={new Date('2021-01-01')}
                 maxDate={new Date('2023-12-01')}
                 value={value}
                 onChange={(newValue) => {
                   setValue(newValue)
+                  changeMonth(newValue)
                 }}
                 inputStyle={{ textAlign: 'center' }}
                 renderInput={(params) => (

--- a/src/pages/User.js
+++ b/src/pages/User.js
@@ -99,6 +99,7 @@ export default function User() {
   const submitData = () => {
     let orders = {
       date: date,
+      month: month,
       time: time,
       paid: total,
       services: customers,


### PR DESCRIPTION
- The daily report now opens current day's orders only.
- The monthly report no longer has year selector
- The routes for a specific month and day has been created (or modified)
- Daily/Monthly shows selected date/month in header
- Delete now works on daily for single clicks
- Current date now has 0 added if month is single digit 
- Removed services from monthly and styled accordingly.